### PR TITLE
Add Software Niagara logo and badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
+[![software niagara](https://github.com/softwareniagara/marketing/blob/master/logos/software-niagara/software-niagara.png)](http://www.softwareniagara.com)
+
 # softwareniagara.com
+
+[![license](https://img.shields.io/badge/license-ISC-blue.svg?style=flat)](LICENSE.md)
+[![license](https://img.shields.io/badge/license-CC-blue.svg?style=flat)](http://creativecommons.org/licenses/by/4.0/)
+[![code of conduct](https://img.shields.io/badge/code%20of%20conduct-contributor%20covenant-ff69b4.svg)](CODE_OF_CONDUCT.md)
 
 This is the repository for the Software Niagara marketing website. It includes
 information on Software Niagara, which is a grassroots initiative to connect


### PR DESCRIPTION
This pull request adds a bit of flare to the README document. It includes a Software Niagara logo with a link to the home page as well as shields for the code license, content license, and code of conduct. These are important documents to link to as they highlight our values of sharing, transparency, and inclusion. 