### PR TITLE
Toggle beacon when user clicks email links

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -29,7 +29,7 @@ title: Welcome to Software Niagara
 
       <p class="lh-copy">
         Check <a href="https://www.meetup.com/software-niagara/">meetup.com</a> for
-        the schedule or email <a href="mailto:info@softwareniagara.com">info@softwareniagara.com</a>
+        the schedule or email <a href="mailto:info@softwareniagara.com" class="js-open-beacon">info@softwareniagara.com</a>
         about presenting.
       </p>
 
@@ -159,7 +159,7 @@ title: Welcome to Software Niagara
       </table>
 
       <p>
-        <a href="mailto:info@softwareniagara.com" class="f5 pa3 button-reset bg-animate bg-pink hover-bg-pink br3 white hover-white db dib-ns tc mt4">Contact us to arrange a demo</a>
+        <a href="mailto:info@softwareniagara.com" class="f5 pa3 button-reset bg-animate bg-pink hover-bg-pink br3 white hover-white db dib-ns tc mt4 js-open-beacon">Contact us to arrange a demo</a>
       </p>
     </div>
   </article>
@@ -190,7 +190,7 @@ title: Welcome to Software Niagara
     our community. Help us build the tech community that you want.
   </p>
   <p class="f6 f4-ns lh-copy measure center tc">
-    <a href="mailto:info@softwareniagara.com" class="f5 pa3 button-reset bg-animate bg-pink hover-bg-pink br3 white hover-white db dib-ns tc mt4">Contact us to volunteer</a>
+    <a href="mailto:info@softwareniagara.com" class="f5 pa3 button-reset bg-animate bg-pink hover-bg-pink br3 white hover-white db dib-ns tc mt4 js-open-beacon">Contact us to volunteer</a>
   </p>
 </article>
 

--- a/source/javascripts/index.js
+++ b/source/javascripts/index.js
@@ -1,11 +1,8 @@
-$(function() {
-  // Testing that stuff works.
-  // TOOD: Delete this once we write some actual JS code.
-  if (__DEVELOPMENT__) {
-    console.log('Running in development mode!');
-  }
-
-  if (__PRODUCTION__) {
-    console.log('Running in production mode!');
-  }
-});
+(function($) {  
+  $(document).ready(function() {
+    $('.js-open-beacon').on('click', function(e) {
+      e.preventDefault();
+      HS && HS.beacon && HS.beacon.open();
+    });
+  });
+})(jQuery);


### PR DESCRIPTION
When user clicks on a a link to send an email to info@softwareniagara.com, toggle the beacon instead as we would rather they contact us that way.