### PR TITLE
Reduce effect of transitions

### DIFF
--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -1,14 +1,9 @@
 import React from 'react'
-import PageTransition from 'gatsby-v2-plugin-page-transitions'
 
 import StyledLayout from './Layout.css'
 
 export default ({ children }) => (
-  <PageTransition
-    transitionTime={750}
-  >
-    <StyledLayout>
-      { children }
-    </StyledLayout>
-  </PageTransition>
+  <StyledLayout>
+    { children }
+  </StyledLayout>
 )

--- a/src/templates/Event.js
+++ b/src/templates/Event.js
@@ -1,4 +1,5 @@
 import Helmet from 'react-helmet'
+import PageTransition from 'gatsby-v2-plugin-page-transitions'
 import React from 'react'
 
 import Action from '../components/Action'
@@ -11,7 +12,11 @@ export default ({ pageContext: { event } } = { event: {} }) => {
       <Action to="/">
         <span role="img" aria-labelledby="button-label">📅</span> <span id="button-label">Back to Events</span>
       </Action>
-      <Event {...event} />
+      <PageTransition
+        transitionTime={300}
+      >
+        <Event {...event} />
+      </PageTransition>
       <Helmet>
         <title>{event.title} | Software Niagara</title>
         <meta name="description" content={event.summary} />

--- a/src/templates/Home.js
+++ b/src/templates/Home.js
@@ -1,4 +1,5 @@
 import Helmet from 'react-helmet'
+import PageTransition from 'gatsby-v2-plugin-page-transitions'
 import React from 'react'
 
 import Action from '../components/Action'
@@ -11,7 +12,11 @@ export default ({ pageContext: { events } } = { events: [] }) => {
       <Action primary to='/code-of-conduct'>
         <span role="img" aria-labelledby="button-label">📜</span> <span id="button-label">Code of Conduct</span>
       </Action>
-      <Events events={events} />
+      <PageTransition
+        transitionTime={300}
+      >
+        <Events events={events} />
+      </PageTransition>
       <Helmet>
         <title>Events | Software Niagara</title>
         <meta name="description" content="Startup and tech events for web and game developers in Niagara" />

--- a/src/templates/Page.js
+++ b/src/templates/Page.js
@@ -1,4 +1,5 @@
 import Helmet from 'react-helmet'
+import PageTransition from 'gatsby-v2-plugin-page-transitions'
 import React from 'react'
 
 import Action from '../components/Action'
@@ -11,7 +12,11 @@ export default ({ pageContext: { page } } = { page: {} }) => {
       <Action to='/'>
         <span role="img" aria-labelledby="button-label">📅</span> <span id="button-label">Back to Events</span>
       </Action>
-      <Page {...page} />
+      <PageTransition
+        transitionTime={300}
+      >
+        <Page {...page} />
+      </PageTransition>
       <Helmet>
         <title>{page.title} | Software Niagara</title>
       </Helmet>


### PR DESCRIPTION
The page transitions implemented in https://github.com/softwareniagara/softwareniagara.com/pull/2 looked and felt great on mobile phones, but were a bit jarring on really large (e.g. 27") screens. 

Animations and transitions are always tricky to nail down. 

Rather than transition the entire page, it was better to transition just the content region as the rest of the page was remaining on changed. I first targeted the Default layout for that, but the trouble was it was transitioning the button under the header which changes from page to page. Because this button has a transform on it, the transform animation would sometimes get cut off by the transition.

That brings us to take three. Moving the transition into the template for more fine grained control. Through this, the main content area is transitioned but the button is not. Because we don't want extreme staggering between when the button pops into view and when the rest of the content pops into view, the transition duration needed to be dialed back to 300ms from 750ms.

We can revisit this in the future, but until we implement proper headers and footers I think this is the best solution for creating a smooth mobile experience that also feels good on the desktop.