### PR TITLE
Add New Events for March

### DIFF
--- a/src/content/events/2019-03-11-devtricks.md
+++ b/src/content/events/2019-03-11-devtricks.md
@@ -1,0 +1,18 @@
+---
+title: "DevTricks 54"
+slug: "devtricks-54"
+category: "devtricks"
+date: "2019-03-11"
+time: "7PM"
+venue: "lws"
+city: "St. Catharines"
+registration: "https://www.facebook.com/events/1075607779276084/"
+---
+
+The last DevTricks of Winter 2019 is upon us. We have three talks lined up for the evening.
+
+1. Importance of Soft Skills in Development - Brian Cline
+2. Hit Hute - Carlo Costantini
+3. Gatsby + Netlify - Nickolas Kenyeres
+
+Next time we see you it will be spring!

--- a/src/content/events/2019-03-26-devcoffee.md
+++ b/src/content/events/2019-03-26-devcoffee.md
@@ -1,0 +1,16 @@
+---
+title: "DevCoffee 7"
+slug: "devcoffee-7"
+category: "devcoffee"
+date: "2019-03-26"
+time: "7PM"
+venue: "finegrind"
+city: "St. Catharines"
+registration: "https://www.facebook.com/events/1451585778308911/"
+---
+
+Come one come all for coffee and conversation! We're meeting at the round tables, towards the back of the cafe. 
+
+Please bring cash. Fine Grind does not accept plastic. Parking is free downtown at this time.
+
+See you there!


### PR DESCRIPTION
This update adds two new events for the month of March in 2019.

1. DevTricks 54 on March 11
2. DevCoffee 7 on March 26
